### PR TITLE
Issue #72 - Edits peak label toggle

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -685,8 +685,8 @@
                     </div>
                     <div id="mapLayersPanel" class="panel-collapse collapse"  aria-labelledby="mapLayerHeader">
                          <div class="panel-body collapse in">
-                            <div id="legendCollapse" class="panel-collapse " role="tabpanel">
-                                <div id="legendDiv" class="panel-body legend-panel-body">
+                           <div id="legendCollapsePanel" class="panel-collapse " role="tabpanel">
+                                <div id="legendDivPanel" class="panel-body legend-panel-body">
                                    <!-- <div id="printout"> -->
                                     <div id="rtScaleAlert" class='alert alert-warning rtScaleAlertClass' role='alert'>Real-time stream and rain gage layers only available at zoom level 9 and above. Please zoom in to view.</div>
                                     <div class="btn-group-vertical lyrTogDiv" style="cursor: pointer;" data-toggle="buttons">
@@ -694,7 +694,7 @@
                                     </div>
                                     <div>
                                     <!--Auto-open the interpreted div-->
-                                    <div id="interpretedToggleDiv" style="display: inline-flex"></div>
+                                    <div id="interpretedToggleDiv" style="text-align: left; display:inline-flex; "></div>
                                     <!--Add toggle for displaying peak labels-->
                                         <label class="switch" id="peakSizeCheck">             
                                             <input type = "checkbox"
@@ -726,12 +726,14 @@
                                     <div class="btn-group-vertical lyrTogDiv" style="cursor: pointer;" data-toggle="buttons">
                                         <button id="supportMapLayer" class="btn btn-default groupToggle" type="button" data-toggle="collapse" data-target="#noaaToggleDiv"  aria-expanded="false" aria-controls="collapseExample" style="font-weight: bold;text-align: left"><b class='groupHeading' style= "font-size: 10pt; text-align: left">Supporting Layers<i class="chevron fa fa-chevron-right pull-right"></i></b></button>
                                     </div>
+                                    <div id="noaaToggleDiv" class="collapse" style="text-align: left"></div>
                                     <div id="noTrackAdvisory"></div>
                                 </div>
                             </div>
                        
                         </div>
                     </div>
+
                 </div>
                 <div class="panel-heading" id="basemapsHeader">
                     <h4 class="panel-title">
@@ -873,6 +875,23 @@
                 
             </div>
 
+            <div id="legendElement" class="panel panel-default legendClass" data-html2canvas-ignore>
+                <div id="legendHeading" class=" legendHeading" role="tab">
+                    <h4 class="panel-title">
+                        <a data-toggle="collapse" style="text-decoration: none"  href="#legendCollapse" aria-expanded="true" aria-controls="collapseOne">
+                            <span class="glyphicon glyphicon-list"></span>
+                            Active Layers
+                        </a>
+                    </h4>
+                </div>
+                <div id="legendCollapse" class="panel-collapse " role="tabpanel">
+                    <div id="legendDiv" class="panel-body legend-panel-body">
+                       
+                    </div>
+                </div>
+            </div>
+        </div>
+
             <div id="homeButton"></div>
             <div id="locateButton"></div>
 
@@ -890,13 +909,6 @@
         <div class="col-xs-7 col-sm-3 col-md-3 sidebar sidebar-right sidebar-animate"></div>
     </div>
 </div>
-
-<!--create checkbox to toggle peak labels-->
-<input type = "checkbox"
-    id = "peakCheckbox"
-    value = "PeakLabels"
-    onclick= "clickPeakLabels()" />
-  <label for = "toggle" class = peakSwitch></label>
 
 </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -688,28 +688,22 @@
                             <div id="legendCollapse" class="panel-collapse " role="tabpanel">
                                 <div id="legendDiv" class="panel-body legend-panel-body">
                                    <!-- <div id="printout"> -->
-                                    
-                                    <div id="rtScaleAlert" class='alert alert-warning rtScaleAlertClass' role='alert'>Real-time stream and rain gage layers only available at <br> zoom level 9 and above. Please zoom in to view.</div>
+                                    <div id="rtScaleAlert" class='alert alert-warning rtScaleAlertClass' role='alert'>Real-time stream and rain gage layers only available at zoom level 9 and above. Please zoom in to view.</div>
                                     <div class="btn-group-vertical lyrTogDiv" style="cursor: pointer;" data-toggle="buttons">
-                                        <button id="interpertedMapLayer" class="btn btn-default groupToggle" type="button" data-toggle="collapse" data-target="#interpretedToggleDiv"  aria-expanded="false" aria-controls="collapseExample" style="font-weight: bold;text-align: left"><b class='groupHeading' style= "font-size: 10pt; text-align: left">Interpreted Data<i class="chevron fa fa-chevron-right pull-right"></i></b></button>
+                                        <button id="interpertedMapLayer" class="btn btn-default groupToggle" type="button" data-toggle="collapse" data-target="#interpretedToggleDiv"  aria-expanded="false" aria-controls="collapseExample" style="font-weight: bold;text-align: left;white-space: nowrap; display: inline-block"><b class='groupHeading' style= "font-size: 10pt; text-align: left">Interpreted Data<i class="chevron fa fa-chevron-right pull-right"></i></b></button> 
                                     </div>
-                                    <div id="interpretedToggleDiv" style="text-align: left">           
+                                    <div>
+                                    <div id="interpretedToggleDiv" style="text-align: left; display: inline-flex">  </div>
                                     <label class="switch" id="peakSizeCheck">             
                                         <input type = "checkbox"
                                         value = "PeakLabels"
                                         id="peakCheckbox"
+                                        
                                         onclick= "clickPeakLabels()" />
                                         <span class="slider round"></span>
-                                        <label for="peakCheckbox"><p>Labels</p></label>
                                     </label>
-                                    
                                     </div>
 
-                                        
-                                    
-
-                                             
-                                   
                                     <div class="btn-group-vertical lyrTogDiv" style="cursor: pointer;" data-toggle="buttons">
                                         <button id="realtimeMapLayer" class="btn btn-default groupToggle groupHeading" type="button" data-toggle="collapse" data-target="#realTimeToggleDiv"  aria-expanded="false" aria-controls="collapseExample" style="font-weight: bold;text-align: left"><b class='groupHeading' style= "font-size: 10pt; text-align: left">Real-Time Data<i class="chevron fa fa-chevron-right pull-right"></i></b></button>
                                     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -690,20 +690,17 @@
                                    <!-- <div id="printout"> -->
                                     <div id="rtScaleAlert" class='alert alert-warning rtScaleAlertClass' role='alert'>Real-time stream and rain gage layers only available at zoom level 9 and above. Please zoom in to view.</div>
                                     <div class="btn-group-vertical lyrTogDiv" style="cursor: pointer;" data-toggle="buttons">
-                                        <button id="interpertedMapLayer" class="btn btn-default groupToggle" type="button" data-toggle="collapse" data-target="#interpretedToggleDiv"  aria-expanded="false" aria-controls="collapseExample" style="font-weight: bold;text-align: left;white-space: nowrap; display: inline-block"><b class='groupHeading' style= "font-size: 10pt; text-align: left">Interpreted Data<i class="chevron fa fa-chevron-right pull-right"></i></b></button> 
+                                        <button id="interpertedMapLayer" class="btn btn-default groupToggle" type="button" data-toggle="collapse" data-target="#interpretedToggleDiv"  aria-expanded="false" aria-controls="collapseExample" style="font-weight: bold;text-align: left"><b class='groupHeading' style= "font-size: 10pt; text-align: left">Interpreted Data<i class="chevron fa fa-chevron-right pull-right"></i></b></button> 
                                     </div>
                                     <div>
-                                    <div id="interpretedToggleDiv" style="text-align: left; display: inline-flex">  </div>
-                                    <label class="switch" id="peakSizeCheck">             
-                                        <input type = "checkbox"
-                                        value = "PeakLabels"
-                                        id="peakCheckbox"
-                                        
-                                        onclick= "clickPeakLabels()" />
-                                        <span class="slider round"></span>
-                                    </label>
+                                    <div id="interpretedToggleDiv" style="display: inline-flex"></div>
+                                        <label class="switch" id="peakSizeCheck">             
+                                            <input type = "checkbox"
+                                            id="peakCheckbox"
+                                            onclick= "clickPeakLabels()" />
+                                            <span class="slider round"></span>
+                                        </label>
                                     </div>
-
                                     <div class="btn-group-vertical lyrTogDiv" style="cursor: pointer;" data-toggle="buttons">
                                         <button id="realtimeMapLayer" class="btn btn-default groupToggle groupHeading" type="button" data-toggle="collapse" data-target="#realTimeToggleDiv"  aria-expanded="false" aria-controls="collapseExample" style="font-weight: bold;text-align: left"><b class='groupHeading' style= "font-size: 10pt; text-align: left">Real-Time Data<i class="chevron fa fa-chevron-right pull-right"></i></b></button>
                                     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -693,7 +693,9 @@
                                         <button id="interpertedMapLayer" class="btn btn-default groupToggle" type="button" data-toggle="collapse" data-target="#interpretedToggleDiv"  aria-expanded="false" aria-controls="collapseExample" style="font-weight: bold;text-align: left"><b class='groupHeading' style= "font-size: 10pt; text-align: left">Interpreted Data<i class="chevron fa fa-chevron-right pull-right"></i></b></button> 
                                     </div>
                                     <div>
+                                    <!--Auto-open the interpreted div-->
                                     <div id="interpretedToggleDiv" style="display: inline-flex"></div>
+                                    <!--Add toggle for displaying peak labels-->
                                         <label class="switch" id="peakSizeCheck">             
                                             <input type = "checkbox"
                                             id="peakCheckbox"

--- a/src/index.html
+++ b/src/index.html
@@ -690,7 +690,23 @@
                                     <div class="btn-group-vertical lyrTogDiv" style="cursor: pointer;" data-toggle="buttons">
                                         <button id="interpertedMapLayer" class="btn btn-default groupToggle" type="button" data-toggle="collapse" data-target="#interpretedToggleDiv"  aria-expanded="false" aria-controls="collapseExample" style="font-weight: bold;text-align: left"><b class='groupHeading' style= "font-size: 10pt; text-align: left">Interpreted Data<i class="chevron fa fa-chevron-right pull-right"></i></b></button>
                                     </div>
-                                    <div id="interpretedToggleDiv" style="text-align: left"></div>
+                                    <div id="interpretedToggleDiv" style="text-align: left">           
+                                    <label class="switch" id="peakSizeCheck">             
+                                        <input type = "checkbox"
+                                        value = "PeakLabels"
+                                        id="peakCheckbox"
+                                        onclick= "clickPeakLabels()" />
+                                        <span class="slider round"></span>
+                                        <label for="peakCheckbox"><p>Labels</p></label>
+                                    </label>
+                                    
+                                    </div>
+
+                                        
+                                    
+
+                                             
+                                   
                                     <div class="btn-group-vertical lyrTogDiv" style="cursor: pointer;" data-toggle="buttons">
                                         <button id="realtimeMapLayer" class="btn btn-default groupToggle groupHeading" type="button" data-toggle="collapse" data-target="#realTimeToggleDiv"  aria-expanded="false" aria-controls="collapseExample" style="font-weight: bold;text-align: left"><b class='groupHeading' style= "font-size: 10pt; text-align: left">Real-Time Data<i class="chevron fa fa-chevron-right pull-right"></i></b></button>
                                     </div>

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -689,7 +689,7 @@ $(document).ready(function () {
 	$('#interpretedToggleDiv').append(interpretedToggle.onAdd(map));
 
 	//add checkbox under Peaks layer in legend to toggle labels on and off
-	$('#interpretedToggleDiv').append(document.getElementById("peakCheckbox"), "Labels");
+	//$('#interpretedToggleDiv').append(document.getElementById("peakCheckbox"), "Labels");
 	//$('.leaflet-top.leaflet-right').hide();
 
 	var noaaToggle = L.control.layers(null, noaaOverlays, { collapsed: false });

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -1846,7 +1846,13 @@ $(document).ready(function () {
 			USGSRainGages.clearLayers();
 			$('#rtScaleAlert').show();
 		}
-
+		if (map.getZoom() < 6){
+			peak.eachLayer(function (myMarker){
+				myMarker.hideLabel();
+			var checkBox = document.getElementById("peakCheckbox");
+			checkBox.checked = false;
+			});
+		}
 		if (map.getZoom() >= 9) {
 			$('#rtScaleAlert').hide();
 		}
@@ -2234,6 +2240,13 @@ $(document).ready(function () {
 //function for toggling peak labels
 function clickPeakLabels() {
 	var checkBox = document.getElementById("peakCheckbox");
+	if (map.getZoom() < 6) {
+		console.log("zoom is less than 6");
+		checkBox.checked = false;
+	}
+	else {
+		console.log("zoom is 6 or greater");
+	}
 	if (checkBox.checked == true) {
 		peak.eachLayer(function (myMarker) {
 			myMarker.showLabel();
@@ -2244,3 +2257,4 @@ function clickPeakLabels() {
 		});
 	}
   }
+  

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -683,15 +683,9 @@ $(document).ready(function () {
 
 	// set up toggle for the interpreted layers and place within legend div, overriding default behavior
 	var interpretedToggle = L.control.layers(null, interpretedOverlays, { collapsed: false });
-
-	//interpretedToggle.append(document.getElementById("peakCheckbox"), "Labels");
 	interpretedToggle.addTo(map);
-
 	$('#interpretedToggleDiv').append(interpretedToggle.onAdd(map));
 
-	//add checkbox under Peaks layer in legend to toggle labels on and off
-	//$('#interpretedToggleDiv').append(document.getElementById("peakCheckbox"), "Labels");
-	//$('.leaflet-top.leaflet-right').hide();
 
 	var noaaToggle = L.control.layers(null, noaaOverlays, { collapsed: false });
 	noaaToggle.addTo(map);
@@ -2098,6 +2092,7 @@ $(document).ready(function () {
 
 		for (var i in srcActiveOverlays) {
 			function imageToBase64(){
+				console.log("scrActiveOverlays", srcActiveOverlays);
 				var canvas = document.createElement("canvas");
 				var ctx = canvas.getContext("2d");
 				var base_image = new Image();

--- a/src/scripts/core.js
+++ b/src/scripts/core.js
@@ -1846,10 +1846,13 @@ $(document).ready(function () {
 			USGSRainGages.clearLayers();
 			$('#rtScaleAlert').show();
 		}
-		if (map.getZoom() < 6){
+		//Remove peak labels and turn off/disable toggle when zoom is less than 8
+		if (map.getZoom() < 8){
+			//Remove labels
 			peak.eachLayer(function (myMarker){
 				myMarker.hideLabel();
 			var checkBox = document.getElementById("peakCheckbox");
+			//Change toggle to 'off' position
 			checkBox.checked = false;
 			});
 		}
@@ -2240,17 +2243,16 @@ $(document).ready(function () {
 //function for toggling peak labels
 function clickPeakLabels() {
 	var checkBox = document.getElementById("peakCheckbox");
-	if (map.getZoom() < 6) {
-		console.log("zoom is less than 6");
+	//Prevent user from using toggle when zoom is less than 8
+	if (map.getZoom() < 8) {
 		checkBox.checked = false;
 	}
-	else {
-		console.log("zoom is 6 or greater");
-	}
+	//Display peak labels when toggle is on
 	if (checkBox.checked == true) {
 		peak.eachLayer(function (myMarker) {
 			myMarker.showLabel();
 		});
+	//Remove peak labels when toggle is off
 	} else {
 		peak.eachLayer(function (myMarker){
 			myMarker.hideLabel();

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -861,6 +861,7 @@ a.lgi-zoom:hover {
   }
   
   .peakCheckbox input { 
+      
     opacity: 0;
     width: 0;
     height: 0;
@@ -916,6 +917,11 @@ a.lgi-zoom:hover {
     width: 30px;
     height: 18px;
     margin-right: 0px;
+  }
+
+  #interpertedMapLayer
+  {
+    white-space: nowrap;
   }
  
 /*MAP LAYERS*/

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -382,8 +382,16 @@ body {
     overflow-y: auto;
     /*max-height: inherit;*/
 }
+#legendDivPanel {
+    overflow-y: auto;
+    /*max-height: inherit;*/
+}
 
 #legendCollapse {
+    /*max-height: inherit;*/
+}
+
+#legendCollapsePanel {
     /*max-height: inherit;*/
 }
 
@@ -1130,6 +1138,19 @@ a.lgi-zoom:hover {
     margin: 0 auto;
 }
 #legendDiv b{
+    box-sizing: border-box;
+    padding: 0 0 0 5px;
+}
+#legendDivPanel p{
+    display: block;
+    box-sizing: border-box;
+    padding: 8px 0 0 0;
+    text-align: center;
+    font-size: 8pt;
+    color: rgba(0,0,0,0.5) !important;
+    margin: 0 auto;
+}
+#legendDivPanel b{
     box-sizing: border-box;
     padding: 0 0 0 5px;
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -918,11 +918,6 @@ a.lgi-zoom:hover {
     height: 18px;
     margin-right: 0px;
   }
-
-  #interpertedMapLayer
-  {
-    white-space: nowrap;
-  }
  
 /*MAP LAYERS*/
 #legendElement{

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -888,6 +888,8 @@ a.lgi-zoom:hover {
     background-color: white;
     transition: .4s;
   }
+
+
   
   input:checked + .slider {
     background-color: #2196F3;
@@ -906,7 +908,7 @@ a.lgi-zoom:hover {
   .slider.round {
     border-radius: 18px;
   }
-  
+ 
   .slider.round:before {
     border-radius: 50%;
   }
@@ -918,7 +920,7 @@ a.lgi-zoom:hover {
     height: 18px;
     margin-right: 0px;
   }
- 
+
 /*MAP LAYERS*/
 #legendElement{
     margin-top: 10px;
@@ -929,12 +931,10 @@ a.lgi-zoom:hover {
     margin-right: 5px;
     color: rgba(0,0,0,0.7) !important;
 }
-
 .esconder {
     display: none;
     /*visibility: hidden;*/
 }
-
 .nwisAlertClass {
     position:absolute;
     top:10px;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -853,8 +853,70 @@ a.lgi-zoom:hover {
 
 
 #peakCheckbox {
-    margin-left: 6px;
-}
+    position: relative;
+    display: inline-block;
+    width: 0px;
+    height: 0px;
+    margin-right: 0px;
+  }
+  
+  .peakCheckbox input { 
+    opacity: 0;
+    width: 0;
+    height: 0;
+  }
+  
+  .slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    transition: .4s;
+  }
+  
+  .slider:before {
+    position: absolute;
+    content: "";
+    height: 13px;
+    width: 13px;
+    left: 2px;
+    bottom: 2px;
+    background-color: white;
+    transition: .4s;
+  }
+  
+  input:checked + .slider {
+    background-color: #2196F3;
+  }
+  
+  input:focus + .slider {
+    box-shadow: 0 0 1px #2196F3;
+  }
+  
+  input:checked + .slider:before {
+    -webkit-transform: translateX(13px);
+    transform: translateX(13px);
+  }
+  
+  /* Rounded sliders */
+  .slider.round {
+    border-radius: 18px;
+  }
+  
+  .slider.round:before {
+    border-radius: 50%;
+  }
+  
+  #peakSizeCheck {
+    position: relative;
+    display: inline-block;
+    width: 30px;
+    height: 18px;
+    margin-right: 0px;
+  }
  
 /*MAP LAYERS*/
 #legendElement{


### PR DESCRIPTION
Zoom threshold is set at 8 because the labels didn't seem to be legible before that - it can be easily changed to anything. 
I didn't add a hover tooltip, but I'll come back to that once other main elements, like the legend are up.